### PR TITLE
Add initial implementation of ProjectMap tool

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,181 @@
+# ProjectMap
+
+A modern Python tool for creating visual maps of project structures in the terminal.
+
+## Installation
+
+```bash
+pip install projectmap
+```
+
+## Features
+- **Interactive Project Mapping**: Visualize your project's structure with clear, hierarchical representations
+- **Smart Filtering**: Built-in ignore patterns for common development artifacts
+- **Flexible Configuration**: Easily customize which files and directories to include or exclude
+- **Clean Unicode Output**: Beautiful terminal visualization using box-drawing characters
+- **Python API & CLI**: Use as a command-line tool or integrate into your Python applications
+- **Intelligent Sorting**: Organized display with directories first, followed by files
+
+## Quick Start
+
+### Command Line
+```bash
+# Map current directory
+projectmap
+
+# Map specific directory
+projectmap --path /path/to/project
+
+# Custom ignore patterns
+projectmap --path . --ignore-dirs "logs" "temp" --ignore-files "*.tmp" "*.bak"
+```
+
+### Python API
+```python
+from projectmap import ProjectStructureVisualizer
+
+# Basic usage
+visualizer = ProjectStructureVisualizer()
+visualizer.visualize('.')
+
+# Custom configuration
+visualizer = ProjectStructureVisualizer(
+    ignore_dirs={'logs', 'temp'},
+    ignore_files={'.env', '*.bak'}
+)
+visualizer.visualize('/path/to/project')
+```
+
+## Example Output
+
+```
+Project Structure (/your/project):
+──────────────────────────────
+├── src
+│   └── projectmap
+│       ├── __init__.py
+│       └── visualizer.py
+├── tests
+│   └── test_visualizer.py
+├── docs
+│   ├── api.md
+│   └── usage.md
+├── README.md
+├── pyproject.toml
+└── LICENSE
+──────────────────────────────
+```
+
+## Configuration
+
+### Default Ignored Patterns
+
+#### Directories
+```python
+DEFAULT_IGNORE_DIRS = {
+    '__pycache__', 
+    '.git', 
+    '.idea', 
+    'venv',
+    '.venv',
+    'env',
+    'node_modules',
+    '.pytest_cache',
+    '.mypy_cache',
+    '.ruff_cache',
+    'build',
+    'dist',
+    'htmlcov',
+    '.coverage',
+    '.tox'
+}
+```
+
+#### Files
+```python
+DEFAULT_IGNORE_FILES = {
+    '.gitignore', 
+    '.env',
+    '.env.local',
+    '.env.development',
+    '.env.production',
+    '.DS_Store',
+    '*.pyc',
+    '*.pyo',
+    '*.pyd',
+    '.python-version',
+    '*.so',
+    '*.egg',
+    '*.egg-info',
+    '*.log',
+    '.coverage',
+    'coverage.xml',
+    '.coverage.*'
+}
+```
+
+## Development Setup
+
+```bash
+# Clone repository
+git clone https://github.com/yourusername/projectmap.git
+cd projectmap
+
+# Create virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install development version
+pip install -e ".[dev]"
+
+# Run tests
+pytest
+```
+
+## Project Structure
+
+```
+projectmap/
+├── src/
+│   └── projectmap/
+│       ├── __init__.py
+│       └── visualizer.py
+├── tests/
+│   └── test_visualizer.py
+├── README.md
+├── pyproject.toml
+└── LICENSE
+```
+
+## Package Configuration (pyproject.toml)
+
+
+## Roadmap
+
+### Version 0.2.0
+- Color output support
+- Export to JSON/YAML
+- Export to image (PNG, SVG)
+- Export to URL (HTML)
+- Custom depth limits
+- File size information
+- Directory statistics
+- Pattern-based filtering
+
+- Git integration
+- Multiple output formats
+- Interactive mode
+
+## Contributing
+
+We welcome contributions! Here's how you can help:
+
+1. Check our [issues page](https://github.com/yourusername/projectmap/issues)
+2. Fork the repository
+3. Create a feature branch
+4. Write your changes
+5. Submit a pull request
+
+## License
+
+MIT License - feel free to use this project for your needs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "projectmap"
+version = "0.1.2"
+description = "A modern tool for visualizing project structures in the terminal"
+readme = "README.md"
+authors = [{ name = "Ivan Akkerman", email = "akakerman.live@gmail.com" }]
+license = { file = "LICENSE" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+keywords = ["project", "structure", "visualization", "tree", "map"]
+dependencies = []
+requires-python = ">=3.7"
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[project.urls]
+Homepage = "https://github.com/mr-akkerman/projectmap"
+
+[project.scripts]
+projectmap = "projectmap.visualizer:main"

--- a/src/projectmap/__init__.py
+++ b/src/projectmap/__init__.py
@@ -1,0 +1,4 @@
+from .visualizer import ProjectStructureVisualizer
+
+__version__ = "0.1.0"
+__all__ = ["ProjectStructureVisualizer"]

--- a/src/projectmap/visualizer.py
+++ b/src/projectmap/visualizer.py
@@ -1,0 +1,109 @@
+import os
+import argparse
+from pathlib import Path
+from typing import Set
+
+
+class ProjectStructureVisualizer:
+    def __init__(self, ignore_dirs: Set[str] = None, ignore_files: Set[str] = None):
+        self.ignore_dirs = ignore_dirs or {
+            '__pycache__',
+            '.git',
+            '.idea',
+            'venv',
+            '.venv',
+            'env',
+            'node_modules',
+            '.pytest_cache',
+            '.mypy_cache',
+            '.ruff_cache',
+            'build',
+            'dist',
+            'htmlcov',
+            '.coverage',
+            '.tox',
+        }
+        self.ignore_files = ignore_files or {
+            '.gitignore',
+            '.env',
+            '.env.local',
+            '.env.development',
+            '.env.production',
+            '.DS_Store',
+            '*.pyc',
+            '*.pyo',
+            '*.pyd',
+            '.python-version',
+            '*.so',
+            '*.egg',
+            '*.egg-info',
+            '*.log',
+            '.coverage',
+            'coverage.xml',
+            '.coverage.*'
+        }
+
+    def _should_ignore(self, name: str, is_dir: bool = False) -> bool:
+        if is_dir:
+            return name in self.ignore_dirs
+
+        for pattern in self.ignore_files:
+            if pattern.startswith('*.'):
+                if name.endswith(pattern[1:]):
+                    return True
+            elif pattern == name:
+                return True
+        return False
+
+    def visualize(self, start_path: str = '.', level: int = 0, prefix: str = '') -> None:
+        path = Path(start_path)
+
+        try:
+            items = list(path.iterdir())
+        except PermissionError:
+            print(f"{prefix}├── [Permission Denied]")
+            return
+
+        items.sort(key=lambda x: (not x.is_dir(), x.name.lower()))
+
+        for index, item in enumerate(items):
+            is_last = index == len(items) - 1
+
+            if self._should_ignore(item.name, item.is_dir()):
+                continue
+
+            current_prefix = '└── ' if is_last else '├── '
+
+            next_level_prefix = '    ' if is_last else '│   '
+
+            print(f"{prefix}{current_prefix}{item.name}")
+
+            if item.is_dir():
+                self.visualize(item, level + 1, prefix + next_level_prefix)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Project structure visualization')
+    parser.add_argument('--path', default='.', help='Path to project root')
+    parser.add_argument('--ignore-dirs', nargs='*', help='Additional directories to ignore')
+    parser.add_argument('--ignore-files', nargs='*', help='Additional files to ignore')
+
+    args = parser.parse_args()
+
+    ignore_dirs = set()
+    ignore_files = set()
+
+    if args.ignore_dirs:
+        ignore_dirs.update(args.ignore_dirs)
+    if args.ignore_files:
+        ignore_files.update(args.ignore_files)
+
+    visualizer = ProjectStructureVisualizer(ignore_dirs, ignore_files)
+    print(f"\nProject structure ({os.path.abspath(args.path)}):")
+    print("─" * 50)
+    visualizer.visualize(args.path)
+    print("─" * 50)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,11 @@
+from projectmap import ProjectStructureVisualizer
+
+def test_should_ignore_directory():
+    visualizer = ProjectStructureVisualizer()
+    assert visualizer._should_ignore('__pycache__', True) == True
+    assert visualizer._should_ignore('src', True) == False
+
+def test_should_ignore_file():
+    visualizer = ProjectStructureVisualizer()
+    assert visualizer._should_ignore('.env', False) == True
+    assert visualizer._should_ignore('main.py', False) == False


### PR DESCRIPTION
Introduce the ProjectMap library for visualizing project structures in the terminal. Includes CLI and Python API, default ignore patterns, project metadata in pyproject.toml, and a test suite. Added README and license files to document and package the tool.