### PR TITLE
Remove outdated version header from roadmap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,6 @@ projectmap/
 
 
 ## Roadmap
-
-### Version 0.2.0
 - Color output support
 - Export to JSON/YAML
 - Export to image (PNG, SVG)


### PR DESCRIPTION
The "Version 0.2.0" header in the roadmap was redundant and did not align with the current structure. This change improves readability and maintains consistency in the document.